### PR TITLE
🎨 Palette: Use CheckboxListTile for scraper fingerprint option

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,1 +1,5 @@
 ## 2024-06-25 - Replace raw GestureDetector with accessible Tooltip+Material+InkWell\n**Learning:** When creating interactive UI elements for hidden/inline text, replacing a raw `GestureDetector` with an `InkWell` wrapped inside a `Material` (with `Colors.transparent`) and `Tooltip` adds visual touch feedback (ripple), ensures keyboard focusability, and provides crucial screen-reader accessibility, satisfying core Flutter UX guidelines.\n**Action:** Prioritize native semantic components (`Tooltip`, `InkWell`) over raw `GestureDetector` for purely interactive elements that lack visual feedback.
+
+## 2024-05-18 - Improve tap target of Checkbox settings
+**Learning:** Raw `Checkbox` wrapped in a `Row` with a `Text` widget creates a tiny tap target for mobile users and poor semantics for screen readers.
+**Action:** Use native `CheckboxListTile` (or `SwitchListTile`) which automatically expands the tap area to the full row width and natively associates the label.

--- a/lib/features/scenes/presentation/widgets/scrape_query_dialog.dart
+++ b/lib/features/scenes/presentation/widgets/scrape_query_dialog.dart
@@ -136,18 +136,16 @@ class _ScrapeQueryDialogState extends ConsumerState<ScrapeQueryDialog> {
             ),
             if (widget.entityType == ScrapeEntityType.scene) ...[
               const SizedBox(height: 16),
-              Row(
-                children: [
-                  Checkbox(
-                    value: _useFingerprints,
-                    onChanged: (val) {
-                      setState(() {
-                        _useFingerprints = val ?? false;
-                      });
-                    },
-                  ),
-                  Text(context.l10n.details_scene_fingerprint_query),
-                ],
+              CheckboxListTile(
+                value: _useFingerprints,
+                onChanged: (val) {
+                  setState(() {
+                    _useFingerprints = val ?? false;
+                  });
+                },
+                title: Text(context.l10n.details_scene_fingerprint_query),
+                controlAffinity: ListTileControlAffinity.leading,
+                contentPadding: EdgeInsets.zero,
               ),
             ],
             const SizedBox(height: 16),

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,4 @@
+💡 What: Replaced the raw `Checkbox` and `Text` wrapped in a `Row` with a native `CheckboxListTile` in the scraper query dialog.
+🎯 Why: Increases the touch target size to the entire row, making it much easier for mobile users to toggle the setting.
+📸 Before/After: Visual appearance is similar but the entire row is now tappable.
+♿ Accessibility: Natively associates the text label with the checkbox, improving the experience for screen reader users.


### PR DESCRIPTION
💡 What: Replaced the raw `Checkbox` and `Text` wrapped in a `Row` with a native `CheckboxListTile` in the scraper query dialog.
🎯 Why: Increases the touch target size to the entire row, making it much easier for mobile users to toggle the setting.
📸 Before/After: Visual appearance is similar but the entire row is now tappable.
♿ Accessibility: Natively associates the text label with the checkbox, improving the experience for screen reader users.

---
*PR created automatically by Jules for task [15685971730180264924](https://jules.google.com/task/15685971730180264924) started by @Alchemist-Aloha*