### PR TITLE
🌐 Localization: Localize mini player semantics label

### DIFF
--- a/lib/features/navigation/presentation/widgets/mini_player.dart
+++ b/lib/features/navigation/presentation/widgets/mini_player.dart
@@ -32,7 +32,7 @@ class MiniPlayer extends ConsumerWidget {
 
     return Semantics(
       button: true,
-      label: 'Now playing: $displayTitle. Tap to open scene details.',
+      label: context.l10n.mini_player_now_playing(displayTitle),
       child: Container(
         height: 66, // Increased height by 10% (from 60)
         decoration: BoxDecoration(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1114,5 +1114,6 @@
   "stats_subtitle_0_unique_items": "0 einzigartige Artikel",
   "markers_search_hint": "Suchmarkierungen",
   "tags_title": "Schlagworte",
-  "scenes_title": "Szenen"
+  "scenes_title": "Szenen",
+  "mini_player_now_playing": "Spielt gerade: {displayTitle}. Tippen Sie hier, um Szenendetails zu öffnen."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1470,5 +1470,13 @@
   "stats_subtitle_0_unique_items": "0 unique items",
   "markers_search_hint": "Search markers",
   "tags_title": "Tags",
-  "scenes_title": "Scenes"
+  "scenes_title": "Scenes",
+  "mini_player_now_playing": "Now playing: {displayTitle}. Tap to open scene details.",
+  "@mini_player_now_playing": {
+    "placeholders": {
+      "displayTitle": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1093,5 +1093,6 @@
   "stats_subtitle_0_unique_items": "0 artículos únicos",
   "markers_search_hint": "Marcadores de búsqueda",
   "tags_title": "Etiquetas",
-  "scenes_title": "Escenas"
+  "scenes_title": "Escenas",
+  "mini_player_now_playing": "Reproduciendo ahora: {displayTitle}. Toque para abrir los detalles de la escena."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1093,5 +1093,6 @@
   "stats_subtitle_0_unique_items": "0 objets uniques",
   "markers_search_hint": "Marqueurs de recherche",
   "tags_title": "Balises",
-  "scenes_title": "Scènes"
+  "scenes_title": "Scènes",
+  "mini_player_now_playing": "Lecture en cours : {displayTitle}. Appuyez pour ouvrir les détails de la scène."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1098,5 +1098,6 @@
   "stats_subtitle_0_unique_items": "0 oggetti unici",
   "markers_search_hint": "Cerca marcatori",
   "tags_title": "Tag",
-  "scenes_title": "Scene"
+  "scenes_title": "Scene",
+  "mini_player_now_playing": "Ora in riproduzione: {displayTitle}. Tocca per aprire i dettagli della scena."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1093,5 +1093,6 @@
   "stats_subtitle_0_unique_items": "0 個のユニークなアイテム",
   "markers_search_hint": "検索マーカー",
   "tags_title": "タグ",
-  "scenes_title": "シーン"
+  "scenes_title": "シーン",
+  "mini_player_now_playing": "現在再生中: {displayTitle}。タップしてシーンの詳細を開きます。"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1093,5 +1093,6 @@
   "stats_subtitle_0_unique_items": "0개의 고유 아이템",
   "markers_search_hint": "검색 마커",
   "tags_title": "태그",
-  "scenes_title": "장면"
+  "scenes_title": "장면",
+  "mini_player_now_playing": "현재 재생 중: {displayTitle}. 장면 세부정보를 열려면 탭하세요."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5681,6 +5681,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Scenes'**
   String get scenes_title;
+
+  /// No description provided for @mini_player_now_playing.
+  ///
+  /// In en, this message translates to:
+  /// **'Now playing: {displayTitle}. Tap to open scene details.'**
+  String mini_player_now_playing(String displayTitle);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3194,4 +3194,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get scenes_title => 'Szenen';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Spielt gerade: $displayTitle. Tippen Sie hier, um Szenendetails zu öffnen.';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3148,4 +3148,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get scenes_title => 'Scenes';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Now playing: $displayTitle. Tap to open scene details.';
+  }
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3221,4 +3221,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get scenes_title => 'Escenas';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Reproduciendo ahora: $displayTitle. Toque para abrir los detalles de la escena.';
+  }
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3213,4 +3213,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get scenes_title => 'Scènes';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Lecture en cours : $displayTitle. Appuyez pour ouvrir les détails de la scène.';
+  }
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3212,4 +3212,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get scenes_title => 'Scene';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Ora in riproduzione: $displayTitle. Tocca per aprire i dettagli della scena.';
+  }
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3086,4 +3086,9 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get scenes_title => 'シーン';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return '現在再生中: $displayTitle。タップしてシーンの詳細を開きます。';
+  }
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3084,4 +3084,9 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get scenes_title => '장면';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return '현재 재생 중: $displayTitle. 장면 세부정보를 열려면 탭하세요.';
+  }
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3189,4 +3189,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get scenes_title => 'Сцены';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return 'Сейчас играет: $displayTitle. Нажмите, чтобы открыть сведения о сцене.';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3029,6 +3029,11 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get scenes_title => '场景';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return '正在播放：$displayTitle。点击可打开场景详细信息。';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).
@@ -6056,6 +6061,11 @@ class AppLocalizationsZhHans extends AppLocalizationsZh {
 
   @override
   String get scenes_title => '场景';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return '正在播放：$displayTitle。点击可打开场景详细信息。';
+  }
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -9087,4 +9097,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get scenes_title => '場景';
+
+  @override
+  String mini_player_now_playing(String displayTitle) {
+    return '正在播放：$displayTitle。點擊可開啟場景詳細資訊。';
+  }
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1093,5 +1093,6 @@
   "stats_subtitle_0_unique_items": "0 уникальных предметов",
   "markers_search_hint": "Маркеры поиска",
   "tags_title": "Теги",
-  "scenes_title": "Сцены"
+  "scenes_title": "Сцены",
+  "mini_player_now_playing": "Сейчас играет: {displayTitle}. Нажмите, чтобы открыть сведения о сцене."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1093,5 +1093,6 @@
   "stats_subtitle_0_unique_items": "0 件独特物品",
   "markers_search_hint": "搜索标记",
   "tags_title": "标签",
-  "scenes_title": "场景"
+  "scenes_title": "场景",
+  "mini_player_now_playing": "正在播放：{displayTitle}。点击可打开场景详细信息。"
 }

--- a/lib/l10n/app_zh_Hans.arb
+++ b/lib/l10n/app_zh_Hans.arb
@@ -1079,5 +1079,6 @@
   "stats_subtitle_0_unique_items": "0 件独特物品",
   "markers_search_hint": "搜索标记",
   "tags_title": "标签",
-  "scenes_title": "场景"
+  "scenes_title": "场景",
+  "mini_player_now_playing": "正在播放：{displayTitle}。点击可打开场景详细信息。"
 }

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -1079,5 +1079,6 @@
   "stats_subtitle_0_unique_items": "0 件獨特物品",
   "markers_search_hint": "搜尋標記",
   "tags_title": "標籤",
-  "scenes_title": "場景"
+  "scenes_title": "場景",
+  "mini_player_now_playing": "正在播放：{displayTitle}。點擊可開啟場景詳細資訊。"
 }


### PR DESCRIPTION
What: Replaced hardcoded string 'Now playing: $displayTitle. Tap to open scene details.' in mini player with l10n key and added translations to all arb files.
Why: Ensure consistent localization and accessibility text across all supported languages.
Impact: Better internationalization support for mini player semantics.

---
*PR created automatically by Jules for task [6852629569283006227](https://jules.google.com/task/6852629569283006227) started by @Alchemist-Aloha*