### PR TITLE
Enhance performer age calculation and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A modern, multi-platform client for your [**Stash server**](https://github.com/s
 The app is primarily tested on Android and Windows. The web build is best treated as a demo because browser restrictions limit authentication and playback behavior. For the full experience, use a native build.
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.30.0-green.svg)](pubspec.yaml)
+[![Version](https://img.shields.io/badge/version-1.31.0-green.svg)](pubspec.yaml)
 
 ## 📸 Screenshots
 

--- a/docs/SPECS.md
+++ b/docs/SPECS.md
@@ -253,9 +253,9 @@ Cover images open the dedicated fullscreen cover viewer with zoom/pan and a
 predictable exit gesture/action.
 
 Performer rows may display age derived from the performer's birthdate and the
-scene date. Age is calculated at the scene date, not the current date; invalid,
-missing, or pre-birth dates omit the suffix without triggering extra performer
-requests.
+scene date. Full birthdates account for whether the birthday had occurred;
+year-only birthdates use calendar-year subtraction. Invalid, missing, or
+pre-birth dates omit the suffix without triggering extra performer requests.
 
 ### Scene rating and metadata mutation
 

--- a/lib/features/scenes/presentation/pages/scene_info_page.dart
+++ b/lib/features/scenes/presentation/pages/scene_info_page.dart
@@ -9,6 +9,7 @@ import '../../domain/entities/scene.dart';
 import '../../../../core/utils/l10n_extensions.dart';
 import '../providers/scene_details_provider.dart';
 import '../widgets/scene_info_media_section.dart';
+import '../widgets/scene_performer_title.dart';
 
 class SceneInfoPage extends ConsumerStatefulWidget {
   const SceneInfoPage({required this.scene, super.key});
@@ -184,6 +185,10 @@ class _SceneInfoPageState extends ConsumerState<SceneInfoPage> {
                           index < scene.performerImagePaths.length
                           ? scene.performerImagePaths[index]
                           : null;
+                      final performerBirthdate =
+                          index < scene.performerBirthdates.length
+                          ? scene.performerBirthdates[index]
+                          : null;
                       final hasImage =
                           performerImagePath != null &&
                           performerImagePath.trim().isNotEmpty &&
@@ -208,10 +213,12 @@ class _SceneInfoPageState extends ConsumerState<SceneInfoPage> {
                                 radius: 14,
                                 child: Icon(Icons.person, size: 14),
                               ),
-                        title: Text(
-                          performerName.isNotEmpty
+                        title: ScenePerformerTitle(
+                          performerName: performerName.isNotEmpty
                               ? performerName
                               : context.l10n.common_unknown,
+                          sceneDate: scene.date,
+                          birthdate: performerBirthdate,
                         ),
                         trailing: const Icon(Icons.chevron_right_rounded),
                         onTap:

--- a/lib/features/scenes/presentation/widgets/scene_performer_title.dart
+++ b/lib/features/scenes/presentation/widgets/scene_performer_title.dart
@@ -1,14 +1,36 @@
 import 'package:flutter/material.dart';
 
-/// Returns the performer's age in the scene's calendar year.
+/// Returns the performer's age on the scene date.
 ///
-/// This intentionally uses year-only subtraction and omits invalid or future
-/// birthdates.
+/// Year-only birthdates use calendar-year subtraction. Full birthdates account
+/// for whether the birthday had occurred. Invalid or future dates are omitted.
 int? ageAtSceneYear({required DateTime sceneDate, String? birthdate}) {
-  final parsedBirthdate = DateTime.tryParse(birthdate?.trim() ?? '');
-  if (parsedBirthdate == null) return null;
+  final match = RegExp(
+    r'^(\d{4})(?:-(\d{2})-(\d{2}))?$',
+  ).firstMatch(birthdate?.trim() ?? '');
+  if (match == null) return null;
 
-  final age = sceneDate.year - parsedBirthdate.year;
+  final birthYear = int.parse(match[1]!);
+  var age = sceneDate.year - birthYear;
+  if (age < 0) return null;
+
+  final month = int.tryParse(match[2] ?? '');
+  final day = int.tryParse(match[3] ?? '');
+  if (month == null || day == null) return age;
+
+  final parsedBirthdate = DateTime.tryParse(
+    '${match[1]}-${match[2]}-${match[3]}',
+  );
+  if (parsedBirthdate == null ||
+      parsedBirthdate.month != month ||
+      parsedBirthdate.day != day) {
+    return null;
+  }
+
+  if (sceneDate.month < month ||
+      (sceneDate.month == month && sceneDate.day < day)) {
+    age--;
+  }
   return age < 0 ? null : age;
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _discoveryapis_commons
-      sha256: "113c4100b90a5b70a983541782431b82168b3cae166ab130649c36eb3559d498"
+      sha256: "55dd9e9cb83f8b62aa5dd8744d3bfedf79d33f9457c1684916c2b5c69c6e3a9b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.7"
+    version: "1.0.8"
   _fe_analyzer_shared:
     dependency: transitive
     description:
@@ -309,10 +309,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      sha256: f141ea4f277af142a0356955707f6556f37b03947d39d55585981a06ca437bd6
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+4"
+    version: "0.3.5+5"
   crypto:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: stash_app_flutter
 description: "A modern Flutter client app for browsing and managing your Stash library."
 publish_to: 'none'
-version: 1.30.0+102
+version: 1.31.0+103
 
 msix_config:
   display_name: StashFlow
   identity_name: com.stashflow.app
   publisher_display_name: StashFlow
-  msix_version: 1.30.0.102
+  msix_version: 1.31.0.103
   logo_path: asset/stashfluttericon.png
 
 environment:

--- a/test/features/scenes/presentation/widgets/scene_performer_title_test.dart
+++ b/test/features/scenes/presentation/widgets/scene_performer_title_test.dart
@@ -5,12 +5,16 @@ import 'package:stash_app_flutter/features/scenes/presentation/widgets/scene_per
 
 void main() {
   group('ageAtSceneYear', () {
-    test('subtracts birth year without adjusting for birthday', () {
+    test('uses the exact birthday when available', () {
       expect(
         ageAtSceneYear(
           sceneDate: DateTime(2020, 1, 1),
           birthdate: '2000-12-31',
         ),
+        19,
+      );
+      expect(
+        ageAtSceneYear(sceneDate: DateTime(2020, 6, 1), birthdate: '2000'),
         20,
       );
     });
@@ -25,6 +29,10 @@ void main() {
       );
       expect(
         ageAtSceneYear(sceneDate: sceneDate, birthdate: '2021-01-01'),
+        isNull,
+      );
+      expect(
+        ageAtSceneYear(sceneDate: sceneDate, birthdate: '2000-02-30'),
         isNull,
       );
     });
@@ -44,12 +52,12 @@ void main() {
       ),
     );
 
-    expect(find.text('Alice (20)', findRichText: true), findsOneWidget);
+    expect(find.text('Alice (19)', findRichText: true), findsOneWidget);
     final text = tester.widget<Text>(find.byType(Text));
     final rootSpan = text.textSpan! as TextSpan;
     final ageSpan = rootSpan.children![1] as TextSpan;
     final context = tester.element(find.byType(ScenePerformerTitle));
-    expect(ageSpan.text, ' (20)');
+    expect(ageSpan.text, ' (19)');
     expect(
       ageSpan.style?.color,
       Theme.of(context).colorScheme.onSurfaceVariant,


### PR DESCRIPTION
This pull request updates performer age calculation logic and improves related UI and tests, as well as bumps the app version to 1.31.0. The main change is that performer ages are now calculated more accurately for scenes, using full birthdates when available and handling edge cases. Tests and documentation are updated to reflect the new logic.

**Performer Age Calculation Improvements:**
- [`scene_performer_title.dart`](diffhunk://#diff-dbb037621702d3527facfbbec32d40f11c68af85dac605fac6cd99e9efa1efe0L3-R33): Refactored `ageAtSceneYear` to use exact birthdates when available, adjusting for whether the birthday had occurred as of the scene date. Year-only birthdates use simple subtraction; invalid or impossible dates return null.
- [`scene_info_page.dart`](diffhunk://#diff-d00c5a155b23ca381a94128789d517fcf02de467922fff37bd864b0d5a227918R188-R191): Passed each performer's birthdate to the performer title widget so the correct age can be displayed per performer. [[1]](diffhunk://#diff-d00c5a155b23ca381a94128789d517fcf02de467922fff37bd864b0d5a227918R188-R191) [[2]](diffhunk://#diff-d00c5a155b23ca381a94128789d517fcf02de467922fff37bd864b0d5a227918L211-R221)

**Testing Updates:**
- [`scene_performer_title_test.dart`](diffhunk://#diff-1f0b3a3dd9a192540fbeede4a2bf60768314ed0c9eed4a93e37927c86e83699cL8-R17): Updated and expanded tests to verify the new age calculation logic, including handling of exact birthdays, year-only birthdates, and invalid dates. [[1]](diffhunk://#diff-1f0b3a3dd9a192540fbeede4a2bf60768314ed0c9eed4a93e37927c86e83699cL8-R17) [[2]](diffhunk://#diff-1f0b3a3dd9a192540fbeede4a2bf60768314ed0c9eed4a93e37927c86e83699cR34-R37) [[3]](diffhunk://#diff-1f0b3a3dd9a192540fbeede4a2bf60768314ed0c9eed4a93e37927c86e83699cL47-R60)

**Version Bump:**
- `pubspec.yaml`, `README.md`: Bumped app version to 1.31.0 and updated related version badges and config. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10)